### PR TITLE
[codex] Update GitHub Actions workflow for Node 24 action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -17,15 +20,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.15.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## What changed
- upgraded `actions/checkout` from `v4` to `v6`
- upgraded `actions/setup-node` from `v4` to `v6`
- upgraded `pnpm/action-setup` from `v4` to `v6`
- added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level

## Why
GitHub Actions is deprecating Node.js 20 for JavaScript actions. This workflow was already installing Node.js 24 for project commands, but several pinned actions still ran on the older action runtime and emitted deprecation warnings.

`vercel/repository-dispatch/actions/status@v1` still declares `node20` upstream, so this PR also opts the workflow into the Node 24 action runtime explicitly until Vercel publishes an updated action version.

## Validation
- verified the workflow file change locally
- verified upstream action metadata:
  - `actions/checkout` now runs on `node24`
  - `actions/setup-node` now runs on `node24`
  - `pnpm/action-setup` now runs on `node24`
  - `vercel/repository-dispatch/actions/status` still declares `node20`

## Impact
This should remove the Node 20 deprecation warning and keep the CI workflow aligned with GitHub's June 2, 2026 switch to Node 24 for JavaScript actions.