### PR TITLE
Add Vercel rewrite configs to route all paths to root

### DIFF
--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/"
-    }
-  ]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a Vercel routing fallback so client-side routes resolve to the single-page app by routing all requests to `/`.

### Description
- Add `vercel.json` at the repository root and `apps/client/vercel.json`, each containing a `rewrites` rule that maps `/(.*)` to `/`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12210110c8324bf451fa7ca27a8de)