### PR TITLE
[codex] Add i18n language preferences

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^4.1.7",
-    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
@@ -14,10 +14,12 @@
     "@types/react-dom": "^18.3.7",
     "graphql": "^16.13.2",
     "graphql-tag": "^2.12.6",
+    "i18next": "^26.0.8",
     "jwt-decode": "^4.0.0",
     "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-i18next": "^17.0.6",
     "react-router-dom": "^7.14.2",
     "semantic-ui-css": "^2.5.0",
     "semantic-ui-react": "^2.1.5"

--- a/apps/client/src/atoms/CommentButton.tsx
+++ b/apps/client/src/atoms/CommentButton.tsx
@@ -1,11 +1,13 @@
 import { Button, Popup } from "semantic-ui-react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 export function CommentButton({ id, commentCount, showLabel = true }) {
+  const { t } = useTranslation();
   return showLabel ? (
     <Popup
       inverted
-      content="Comment on post"
+      content={t("actions.commentOnPost")}
       trigger={
         <Button
           as={Link}
@@ -24,7 +26,7 @@ export function CommentButton({ id, commentCount, showLabel = true }) {
   ) : (
     <Popup
       inverted
-      content="Comment on post"
+      content={t("actions.commentOnPost")}
       trigger={
         <Button
           as={Link}

--- a/apps/client/src/atoms/DeleteButton.tsx
+++ b/apps/client/src/atoms/DeleteButton.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@apollo/client/react";
 import { useState } from "react";
 import { Button, Popup, Confirm } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 import { FETCH_POSTS_QUERY } from "../util/GraphQL";
 
 export function DeleteButton({
@@ -20,7 +21,9 @@ export function DeleteButton({
   mutation: any;
   basic?: boolean;
 }): JSX.Element {
+  const { t } = useTranslation();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const deleteLabel = commentId ? t("dialogs.deleteComment") : t("dialogs.deletePost");
 
   const [deleteCommentorPostMutation] = useMutation<any>(mutation, {
     update(proxy) {
@@ -44,10 +47,10 @@ export function DeleteButton({
 
   return (
     <>
-      <MyPopup content={commentId ? "Delete comment" : "Delete post"}>
+      <MyPopup content={deleteLabel}>
         {user && user.username === username && (
           <Popup
-            content={commentId ? "Delete comment" : "Delete post"}
+            content={deleteLabel}
             inverted
             trigger={
               <div style={{ width: "40px" }}>
@@ -69,6 +72,9 @@ export function DeleteButton({
       </MyPopup>
       <Confirm
         open={confirmOpen}
+        cancelButton={t("actions.cancel")}
+        confirmButton={t("actions.confirm")}
+        content={t("dialogs.destructiveDescription")}
         onCancel={() => setConfirmOpen(false)}
         onConfirm={(e: React.SyntheticEvent) => {
           e.preventDefault();

--- a/apps/client/src/atoms/LikeButton.tsx
+++ b/apps/client/src/atoms/LikeButton.tsx
@@ -3,12 +3,14 @@ import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useMutation } from "@apollo/client/react";
 import { LIKE_POST } from "../util/GraphQL";
+import { useTranslation } from "react-i18next";
 
 export function LikeButton({
   post: { id, likeCount, likes },
   user,
   showLabel = true,
 }) {
+  const { t } = useTranslation();
   const [liked, setLiked] = useState(false);
 
   useEffect(() => {
@@ -33,7 +35,7 @@ export function LikeButton({
     <>
       {user && showLabel && (
         <Popup
-          content="Like Post"
+          content={t("actions.likePost")}
           inverted
           trigger={
             <Button
@@ -51,7 +53,7 @@ export function LikeButton({
       )}
       {!user && showLabel && (
         <Popup
-          content="Like Post"
+          content={t("actions.likePost")}
           inverted
           trigger={
             <Button
@@ -70,7 +72,7 @@ export function LikeButton({
       )}
       {user && !showLabel && (
         <Popup
-          content="Like Post"
+          content={t("actions.likePost")}
           inverted
           trigger={
             <Button
@@ -84,7 +86,7 @@ export function LikeButton({
       )}
       {!user && !showLabel && (
         <Popup
-          content="Like Post"
+          content={t("actions.likePost")}
           inverted
           trigger={
             <Button as={Link} to={"/login"} basic color="red" icon="heart" />

--- a/apps/client/src/atoms/LikeLine.tsx
+++ b/apps/client/src/atoms/LikeLine.tsx
@@ -1,19 +1,23 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 export function LikeLine({ post: { likes }, user }) {
+  const { t } = useTranslation();
   const likeLength = likes?.length;
+  const displayName = (username: string) => username === user?.username ? t("likes.you") : username;
+
   if (likes) {
     switch (true) {
       case likeLength === 1:
         if (likes[0].username === user?.username) {
-          return <p>You liked this.</p>;
+          return <p>{t("likes.youLiked")}</p>;
         } else {
           return (
             <p>
               <Link to={`/profile/${likes[0].username}`}>
                 {`${likes[0].username}`}
               </Link>{" "}
-              liked this.
+              {t("likes.likedThisSingular")}
             </p>
           );
         }
@@ -21,20 +25,14 @@ export function LikeLine({ post: { likes }, user }) {
       case likeLength === 2:
         return (
           <p>
-            <strong>{`${
-              likes[1].username === user?.username ? "You" : likes[1].username
-            }`}</strong>{" "}
-            and{" "}
+            <strong>{displayName(likes[1].username)}</strong>{" "}
+            {t("likes.and")}{" "}
             <strong>
               <Link to={`/profile/${likes[0].username}`}>
-                {`${
-                  likes[0].username === user?.username
-                    ? "You"
-                    : likes[0].username
-                }`}
+                {displayName(likes[0].username)}
               </Link>
             </strong>{" "}
-            liked this.
+            {t("likes.likedThisPlural")}
           </p>
         );
 
@@ -43,34 +41,22 @@ export function LikeLine({ post: { likes }, user }) {
           <p>
             <strong>
               <Link to={`/profile/${likes[2].username}`}>
-                {`${
-                  likes[2].username === user?.username
-                    ? "You"
-                    : likes[2].username
-                }`}
+                {displayName(likes[2].username)}
               </Link>
             </strong>
             ,{" "}
             <strong>
               <Link to={`/profile/${likes[1].username}`}>
-                {`${
-                  likes[1].username === user?.username
-                    ? "You"
-                    : likes[1].username
-                }`}
+                {displayName(likes[1].username)}
               </Link>
             </strong>{" "}
-            and{" "}
+            {t("likes.and")}{" "}
             <strong>
               <Link to={`/profile/${likes[0].username}`}>
-                {`${
-                  likes[0].username === user?.username
-                    ? "You"
-                    : likes[0].username
-                }`}
+                {displayName(likes[0].username)}
               </Link>
             </strong>{" "}
-            liked this.
+            {t("likes.likedThisPlural")}
           </p>
         );
 
@@ -79,42 +65,28 @@ export function LikeLine({ post: { likes }, user }) {
           <p>
             <strong>
               <Link to={`/profile/${likes[2].username}`}>
-                {`${
-                  likes[2].username === user?.username
-                    ? "You"
-                    : likes[2].username
-                }`}
+                {displayName(likes[2].username)}
               </Link>
             </strong>
             ,
             <strong>
               {" "}
               <Link to={`/profile/${likes[1].username}`}>
-                {`${
-                  likes[1].username === user?.username
-                    ? "You"
-                    : likes[1].username
-                }`}
+                {displayName(likes[1].username)}
               </Link>
             </strong>
             ,{" "}
             <strong>
               <Link to={`/profile/${likes[0].username}`}>
-                {`${
-                  likes[0].username === user?.username
-                    ? "You"
-                    : likes[0].username
-                }`}
+                {displayName(likes[0].username)}
               </Link>
             </strong>
-            {` and ${likeLength - 3} more  ${
-              likeLength - 3 === 1 ? "person" : "people"
-            } liked this.`}
+            {` ${t("likes.and")} ${t("likes.others", { count: likeLength - 3 })} ${t("likes.likedThisPlural")}`}
           </p>
         );
 
       default:
-        return <p>Nobody Liked This</p>;
+        return <p>{t("likes.nobody")}</p>;
     }
   } else return <></>;
 }

--- a/apps/client/src/atoms/ProfilePictureSelector.tsx
+++ b/apps/client/src/atoms/ProfilePictureSelector.tsx
@@ -1,9 +1,11 @@
 import { Grid, GridColumn, Image } from "semantic-ui-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getPictureURL } from "../util/profilePictureDictionary";
 import { profilePictureDictionary } from "../util/profilePictureDictionary";
 
 export function ProfilePictureSelector({ values, update = false }) {
+  const { t } = useTranslation();
   const [selectedPicture, setSelectedPicture] = useState(values.profilePicture);
   const [loadingPic, setLoadingPic] = useState(true);
 
@@ -32,7 +34,7 @@ export function ProfilePictureSelector({ values, update = false }) {
             textAlign: "center",
           }}
         >
-          {`  Select ${update ? "a new" : "an"} Avatar`}
+          {t(update ? "profile.selectNewAvatar" : "profile.selectAvatar")}
         </h2>
       </Grid.Row>
       <Grid.Row>

--- a/apps/client/src/components/Ad.tsx
+++ b/apps/client/src/components/Ad.tsx
@@ -1,6 +1,8 @@
 import { Card } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 
 export default function Ad() {
+  const { t } = useTranslation();
   return (
     <>
       <Card
@@ -23,7 +25,7 @@ export default function Ad() {
               width: "90%",
             }}
           >
-            See what our users are talking about right now! 🌎
+            {t("welcome.ad")} 🌎
           </Card.Header>
         </Card.Content>
       </Card>

--- a/apps/client/src/components/Comments.tsx
+++ b/apps/client/src/components/Comments.tsx
@@ -1,14 +1,16 @@
 import moment from "moment";
 import { Comment, Header } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 import { DeleteButton } from "../atoms/DeleteButton";
 import { DELETE_COMMENT_MUTATION } from "../util/GraphQL";
 import NewComment from "./NewComment";
 import { getPictureURL } from "../util/profilePictureDictionary";
 export default function Comments({ comments, commentCount, id, user }) {
+  const { t } = useTranslation();
   return (
     <Comment.Group>
       <Header as="h3" dividing>
-        {commentCount} Comments
+        {t("comments.count", { count: commentCount })}
       </Header>
 
       {comments.map((comment: any, index: number) => (

--- a/apps/client/src/components/MenuBar.tsx
+++ b/apps/client/src/components/MenuBar.tsx
@@ -1,18 +1,21 @@
-import { useState, useContext } from "react";
+import { useState, useContext, type ChangeEvent } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { useMutation } from "@apollo/client/react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 import { Image, Menu, MenuItemProps } from "semantic-ui-react";
 import { AuthContext } from "../context/auth";
-import { LOGOUT_USER, ME_QUERY } from "../util/GraphQL";
+import { LOGOUT_USER, ME_QUERY, UPDATE_PREFERRED_LANGUAGE } from "../util/GraphQL";
 import { getPictureURL } from "../util/profilePictureDictionary";
 import { useDisplayProfile } from "../util/hooks";
 import Profile from "../pages/User";
+import { setPreferredLanguage, type SupportedLanguage } from "../i18n";
 
 export default function MenuBar() {
+  const { i18n, t } = useTranslation();
   const client = useApolloClient();
-  const { user, logout }: { user: any; logout: any } = useContext(AuthContext);
+  const { user, login, logout }: { user: any; login: any; logout: any } = useContext(AuthContext);
 
   const pathname = window.location.pathname;
 
@@ -35,6 +38,17 @@ export default function MenuBar() {
       logout();
     },
   });
+  const [updatePreferredLanguage] = useMutation<any>(UPDATE_PREFERRED_LANGUAGE, {
+    onCompleted: ({ updatePreferredLanguage: userData }) => login(userData),
+  });
+
+  function onLanguageChange(event: ChangeEvent<HTMLSelectElement>) {
+    const preferredLanguage = event.target.value as SupportedLanguage;
+    setPreferredLanguage(preferredLanguage);
+    if (user) {
+      void updatePreferredLanguage({ variables: { preferredLanguage } });
+    }
+  }
 
   const handleItemClick = (
     e: React.SyntheticEvent<any, any>,
@@ -52,6 +66,15 @@ export default function MenuBar() {
         </Link>
       </Menu.Item>
       <Menu.Menu position="right">
+        <Menu.Item>
+          <label style={{ display: "flex", alignItems: "center", gap: ".5rem" }}>
+            <span>{t("languages.label")}</span>
+            <select aria-label={t("languages.label")} value={i18n.language.startsWith("pt") ? "pt" : "en"} onChange={onLanguageChange}>
+              <option value="en">{t("languages.en")}</option>
+              <option value="pt">{t("languages.pt")}</option>
+            </select>
+          </label>
+        </Menu.Item>
         <Menu.Item
           onClick={onClick}
           style={{
@@ -73,7 +96,7 @@ export default function MenuBar() {
           }
         />
         <Menu.Item
-          name="logout"
+          name={t("actions.logout")}
           onClick={() => {
             void logoutUser();
           }}
@@ -104,8 +127,18 @@ export default function MenuBar() {
       </Menu.Item>
 
       <Menu.Menu position="right">
+        <Menu.Item>
+          <label style={{ display: "flex", alignItems: "center", gap: ".5rem" }}>
+            <span>{t("languages.label")}</span>
+            <select aria-label={t("languages.label")} value={i18n.language.startsWith("pt") ? "pt" : "en"} onChange={onLanguageChange}>
+              <option value="en">{t("languages.en")}</option>
+              <option value="pt">{t("languages.pt")}</option>
+            </select>
+          </label>
+        </Menu.Item>
         <Menu.Item
           name="login"
+          content={t("actions.login")}
           active={activeItem === "login"}
           onClick={handleItemClick}
           as={Link}
@@ -114,6 +147,7 @@ export default function MenuBar() {
         />
         <Menu.Item
           name="register"
+          content={t("actions.register")}
           active={activeItem === "register"}
           onClick={handleItemClick}
           as={Link}

--- a/apps/client/src/components/NewComment.tsx
+++ b/apps/client/src/components/NewComment.tsx
@@ -1,11 +1,13 @@
 import { useMutation } from "@apollo/client/react";
 
 import { Button, Form } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 
 import { CREATE_COMMENT_MUTATION } from "../util/GraphQL";
 import { useForm } from "../util/hooks";
 
 export default function NewComment({ id }) {
+  const { t } = useTranslation();
   const { onChange, onSubmit, values } = useForm(createCommentCallback, {
     body: "",
   });
@@ -32,12 +34,12 @@ export default function NewComment({ id }) {
               color: "#9f3a38",
               fontWeight: "400",
             }}
-          ></p>
+          >{t("newComment.error")}</p>
         )}
 
         <Form.Field>
           <Form.TextArea
-            placeholder="Add your comment"
+            placeholder={t("newComment.placeholder")}
             name="body"
             onChange={onChange}
             value={values.body}
@@ -46,7 +48,7 @@ export default function NewComment({ id }) {
         </Form.Field>
 
         <Button
-          content="Add Comment"
+          content={t("actions.addComment")}
           labelPosition="left"
           icon="edit"
           color="purple"

--- a/apps/client/src/components/NewPost.tsx
+++ b/apps/client/src/components/NewPost.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from '@apollo/client/react';
 import { Button, Form, Card } from 'semantic-ui-react';
+import { useTranslation } from 'react-i18next';
 
 import { CREATE_POST_MUTATION, FETCH_POSTS_QUERY } from '../util/GraphQL';
 import { getGraphQLErrorMessage } from '../util/errors';
@@ -8,6 +9,7 @@ import { useForm } from '../util/hooks';
 const MAX_POST_BODY_LENGTH = 512;
 
 export default function NewPost() {
+  const { t } = useTranslation();
   const { onChange, onSubmit, values } = useForm(createPostCallback, {
     body: '',
   });
@@ -39,7 +41,7 @@ export default function NewPost() {
         >
           <Card.Content color='black'>
             <Card.Header>
-              <h3>New Post</h3>
+              <h3>{t("newPost.title")}</h3>
               {error && (
                 <p
                   className='ui error'
@@ -49,7 +51,7 @@ export default function NewPost() {
                     fontWeight: '400',
                   }}
                 >
-                  {getGraphQLErrorMessage(error)}!
+                  {getGraphQLErrorMessage(error)}{t("newPost.errorSuffix")}
                 </p>
               )}
             </Card.Header>
@@ -57,7 +59,7 @@ export default function NewPost() {
             <Card.Description style={{ marginTop: '1rem' }}>
               <Form.Field>
                 <Form.TextArea
-                  placeholder='Say hi to the World!'
+                  placeholder={t("newPost.placeholder")}
                   name='body'
                   onChange={onChange}
                   value={values.body}
@@ -87,7 +89,7 @@ export default function NewPost() {
               type='submit'
               color='purple'
             >
-              Send
+              {t("actions.send")}
             </Button>
           </Card.Content>
         </Card>

--- a/apps/client/src/context/auth.tsx
+++ b/apps/client/src/context/auth.tsx
@@ -3,6 +3,7 @@ import { createContext, useEffect, useReducer } from "react";
 import { useQuery } from "@apollo/client/react";
 
 import { ME_QUERY } from "../util/GraphQL";
+import { setPreferredLanguage, type SupportedLanguage } from "../i18n";
 
 export interface AuthUser {
   id: string;
@@ -10,6 +11,7 @@ export interface AuthUser {
   email: string;
   createdAt: string;
   profilePicture: string;
+  preferredLanguage?: SupportedLanguage | null;
   token?: string | null;
 }
 
@@ -60,6 +62,9 @@ function AuthProvider({ children }: PropsWithChildren): JSX.Element {
   useEffect(() => {
     if (data?.me) {
       dispatch({ type: "LOGIN", payload: data.me });
+      if (data.me.preferredLanguage) {
+        setPreferredLanguage(data.me.preferredLanguage);
+      }
       return;
     }
 
@@ -75,6 +80,10 @@ function AuthProvider({ children }: PropsWithChildren): JSX.Element {
     login: (userData: AuthUser) => {
       if (userData.token) {
         window.localStorage.setItem("authToken", userData.token);
+      }
+
+      if (userData.preferredLanguage) {
+        setPreferredLanguage(userData.preferredLanguage);
       }
 
       dispatch({ type: "LOGIN", payload: userData });

--- a/apps/client/src/graphql/schema.graphql
+++ b/apps/client/src/graphql/schema.graphql
@@ -24,6 +24,7 @@ type Mutation {
   register(registerInput: RegisterInput!): User!
   requestPasswordReset(email: String!): PasswordResetResponse!
   resetPassword(confirmPassword: String!, password: String!, token: String!): PasswordResetResponse!
+  updatePreferredLanguage(preferredLanguage: String!): User!
   updateUser(updateProfileInput: UpdateProfileInput!): User!
 }
 
@@ -67,6 +68,7 @@ input UpdateProfileInput {
   newUsername: String!
   oldPassword: String!
   oldUsername: String!
+  preferredLanguage: String
   profilePicture: String!
 }
 
@@ -74,6 +76,7 @@ type User {
   createdAt: String!
   email: String!
   id: ID!
+  preferredLanguage: String
   profilePicture: String!
   token: String
   username: String!

--- a/apps/client/src/i18n.ts
+++ b/apps/client/src/i18n.ts
@@ -1,0 +1,255 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import moment from "moment";
+import "moment/dist/locale/pt-br";
+
+export const LANGUAGE_STORAGE_KEY = "hiworld.preferredLanguage";
+export const SUPPORTED_LANGUAGES = ["en", "pt"] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+function normalizeLanguage(language?: string | null): SupportedLanguage | null {
+  const normalized = language?.toLowerCase().split("-")[0];
+  return normalized === "pt" || normalized === "en" ? normalized : null;
+}
+
+export function getStoredLanguage(): SupportedLanguage | null {
+  try {
+    return normalizeLanguage(window.localStorage.getItem(LANGUAGE_STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function getOsLanguage(): SupportedLanguage {
+  const languages = navigator.languages?.length ? navigator.languages : [navigator.language];
+  return languages.map(normalizeLanguage).find(Boolean) ?? "en";
+}
+
+export function setPreferredLanguage(language: SupportedLanguage) {
+  window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+  void i18n.changeLanguage(language);
+}
+
+function setMomentLocale(language: SupportedLanguage) {
+  moment.locale(language === "pt" ? "pt-br" : "en");
+}
+
+const resources = {
+  en: {
+    translation: {
+      actions: {
+        addComment: "Add Comment",
+        backToLogin: "Back to login",
+        cancel: "Cancel",
+        confirm: "Confirm",
+        commentOnPost: "Comment on post",
+        editProfile: "Edit Profile",
+        goToLogin: "Go to login",
+        login: "login",
+        logout: "logout",
+        likePost: "Like Post",
+        register: "register",
+        resetPassword: "Reset Password",
+        saveChanges: "Save Changes",
+        send: "Send",
+        sendResetLink: "Send Reset Link",
+      },
+      comments: {
+        count_one: "{{count}} Comment",
+        count_other: "{{count}} Comments",
+      },
+      common: {
+        email: "E-mail",
+        error: "Error: {{message}}",
+        loading: "Loading...",
+        password: "Password",
+        username: "Username",
+      },
+      dialogs: {
+        deleteComment: "Delete comment",
+        deletePost: "Delete post",
+        destructiveDescription: "This action cannot be undone.",
+      },
+      forgotPassword: {
+        checkEmail: "Check your email",
+        description: "Enter your email address and, if an account exists, you'll receive a password reset link.",
+        title: "Forgot Password",
+      },
+      home: {
+        loadingPosts: "Loading posts",
+        recentPosts: "Recent Posts",
+      },
+      languages: {
+        en: "English",
+        label: "Language",
+        pt: "Portuguese",
+      },
+      likes: {
+        and: "and",
+        likedBy: "{{names}} liked this.",
+        likedThisPlural: "liked this.",
+        likedThisSingular: "liked this.",
+        nobody: "Nobody Liked This",
+        others_one: "{{count}} other person",
+        others_other: "{{count}} other people",
+        you: "You",
+        youLiked: "You liked this.",
+      },
+      newComment: {
+        error: "Could not add comment.",
+        placeholder: "Add your comment",
+      },
+      newPost: {
+        errorSuffix: "!",
+        placeholder: "Say hi to the World!",
+        title: "New Post",
+      },
+      profile: {
+        selectAvatar: "Select an Avatar",
+        selectNewAvatar: "Select a new Avatar",
+        joined: "Joined {{time}}",
+      },
+      profileForm: {
+        confirmNewPassword: "Confirm New Password",
+        newPassword: "New Password",
+        newUsername: "New Username (Leave Blank if you don't want to change it)",
+        oldPassword: "Old Password",
+        title: "Edit Profile",
+      },
+      register: {
+        confirmPassword: "Confirm Password",
+        title: "Register",
+      },
+      resetPassword: {
+        invalidToken: "Reset link is invalid or expired.",
+        passwordUpdated: "Password updated",
+        title: "Reset Password",
+      },
+      singlePost: {
+        loading: "Loading post",
+        notFound: "Error! No post could be found.",
+      },
+      welcome: {
+        ad: "See what our users are talking about right now!",
+      },
+    },
+  },
+  pt: {
+    translation: {
+      actions: {
+        addComment: "Adicionar comentario",
+        backToLogin: "Voltar ao login",
+        cancel: "Cancelar",
+        confirm: "Confirmar",
+        commentOnPost: "Comentar na publicacao",
+        editProfile: "Editar perfil",
+        goToLogin: "Ir para o login",
+        login: "entrar",
+        logout: "sair",
+        likePost: "Curtir publicacao",
+        register: "cadastrar",
+        resetPassword: "Redefinir senha",
+        saveChanges: "Salvar alteracoes",
+        send: "Enviar",
+        sendResetLink: "Enviar link de redefinicao",
+      },
+      comments: {
+        count_one: "{{count}} Comentario",
+        count_other: "{{count}} Comentarios",
+      },
+      common: {
+        email: "E-mail",
+        error: "Erro: {{message}}",
+        loading: "Carregando...",
+        password: "Senha",
+        username: "Nome de usuario",
+      },
+      dialogs: {
+        deleteComment: "Excluir comentario",
+        deletePost: "Excluir publicacao",
+        destructiveDescription: "Esta acao nao pode ser desfeita.",
+      },
+      forgotPassword: {
+        checkEmail: "Verifique seu e-mail",
+        description: "Informe seu e-mail e, se existir uma conta, voce recebera um link para redefinir a senha.",
+        title: "Esqueci minha senha",
+      },
+      home: {
+        loadingPosts: "Carregando publicacoes",
+        recentPosts: "Publicacoes recentes",
+      },
+      languages: {
+        en: "Ingles",
+        label: "Idioma",
+        pt: "Portugues",
+      },
+      likes: {
+        and: "e",
+        likedBy: "{{names}} curtiram isto.",
+        likedThisPlural: "curtiram isto.",
+        likedThisSingular: "curtiu isto.",
+        nobody: "Ninguem curtiu isto",
+        others_one: "{{count}} outra pessoa",
+        others_other: "{{count}} outras pessoas",
+        you: "Voce",
+        youLiked: "Voce curtiu isto.",
+      },
+      newComment: {
+        error: "Nao foi possivel adicionar o comentario.",
+        placeholder: "Adicione seu comentario",
+      },
+      newPost: {
+        errorSuffix: "!",
+        placeholder: "Diga oi ao mundo!",
+        title: "Nova publicacao",
+      },
+      profile: {
+        selectAvatar: "Selecione um avatar",
+        selectNewAvatar: "Selecione um novo avatar",
+        joined: "Entrou {{time}}",
+      },
+      profileForm: {
+        confirmNewPassword: "Confirmar nova senha",
+        newPassword: "Nova senha",
+        newUsername: "Novo nome de usuario (deixe em branco se nao quiser alterar)",
+        oldPassword: "Senha atual",
+        title: "Editar perfil",
+      },
+      register: {
+        confirmPassword: "Confirmar senha",
+        title: "Cadastro",
+      },
+      resetPassword: {
+        invalidToken: "O link de redefinicao e invalido ou expirou.",
+        passwordUpdated: "Senha atualizada",
+        title: "Redefinir senha",
+      },
+      singlePost: {
+        loading: "Carregando publicacao",
+        notFound: "Erro! Nenhuma publicacao foi encontrada.",
+      },
+      welcome: {
+        ad: "Veja o que nossos usuarios estao falando agora!",
+      },
+    },
+  },
+};
+
+i18n.use(initReactI18next).init({
+  fallbackLng: "en",
+  interpolation: {
+    escapeValue: false,
+  },
+  lng: getStoredLanguage() ?? getOsLanguage(),
+  react: {
+    useSuspense: false,
+  },
+  resources,
+});
+
+setMomentLocale(i18n.language === "pt" ? "pt" : "en");
+i18n.on("languageChanged", (language) => {
+  setMomentLocale(language === "pt" ? "pt" : "en");
+});
+
+export default i18n;

--- a/apps/client/src/index.tsx
+++ b/apps/client/src/index.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from "react-dom/client";
+import "./i18n";
 import ApolloProvider from "./ApolloProvider";
 
 const root = ReactDOM.createRoot(

--- a/apps/client/src/pages/EditProfile.tsx
+++ b/apps/client/src/pages/EditProfile.tsx
@@ -1,5 +1,6 @@
-import { useState, useContext } from "react";
+import { useState, useContext, type ChangeEvent } from "react";
 import { Form, Button, Container, Grid, Loader } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 import { useForm } from "../util/hooks";
 import { useMutation } from "@apollo/client/react";
 import { UPDATE_USER_MUTATION } from "../util/GraphQL";
@@ -7,8 +8,10 @@ import { getGraphQLErrors } from "../util/errors";
 import { useNavigate } from "react-router-dom";
 import { AuthContext } from "../context/auth";
 import { ProfilePictureSelector } from "../atoms/ProfilePictureSelector";
+import { setPreferredLanguage, type SupportedLanguage } from "../i18n";
 
 export function EditProfile() {
+  const { i18n, t } = useTranslation();
   const navigate = useNavigate();
   const context = useContext(AuthContext) as any;
   const user = context.user;
@@ -21,6 +24,7 @@ export function EditProfile() {
     newPassword: "",
     confirmPassword: "",
     profilePicture: user.profilePicture,
+    preferredLanguage: user.preferredLanguage ?? i18n.language,
   };
 
   const { onChange, onSubmit, values } = useForm(updateUser, initialState);
@@ -43,11 +47,16 @@ export function EditProfile() {
     changeUser();
   }
 
+  function onLanguageChange(e: ChangeEvent<HTMLSelectElement>) {
+    onChange(e);
+    setPreferredLanguage(e.target.value as SupportedLanguage);
+  }
+
   return loading ? (
     <Loader active />
   ) : (
     <Container>
-      <h1>Edit Profile</h1>
+      <h1>{t("profileForm.title")}</h1>
       {Object.keys(errors)?.length > 0 && (
         <div className="ui error message">
           <ul className="list">
@@ -59,55 +68,60 @@ export function EditProfile() {
       )}
       <Form onSubmit={onSubmit}>
         <Form.Field>
-          <label>
-            New Username (Leave Blank if you don't want to change it)
-          </label>
+          <label>{t("profileForm.newUsername")}</label>
           <input
             name="newUsername"
-            placeholder="Username"
+            placeholder={t("common.username")}
             value={values.newUsername}
             onChange={onChange}
           />
         </Form.Field>
 
         <Form.Field>
-          <label>Email</label>
+          <label>{t("common.email")}</label>
           <input
-            placeholder="email"
+            placeholder={t("common.email")}
             name="email"
             value={values.email}
             onChange={onChange}
           />
         </Form.Field>
         <Form.Field>
-          <label>Old Password</label>
+          <label>{t("profileForm.oldPassword")}</label>
           <input
             name="oldPassword"
             type="password"
-            placeholder="Password"
+            placeholder={t("common.password")}
             value={values.oldPassword}
             onChange={onChange}
           />
         </Form.Field>
         <Form.Field>
-          <label>New Password</label>
+          <label>{t("profileForm.newPassword")}</label>
           <input
             name="newPassword"
             type="password"
-            placeholder="Password"
+            placeholder={t("profileForm.newPassword")}
             value={values.newPassword}
             onChange={onChange}
           />
         </Form.Field>
         <Form.Field>
-          <label>Confirm New Password</label>
+          <label>{t("profileForm.confirmNewPassword")}</label>
           <input
             type="password"
-            placeholder="Password"
+            placeholder={t("profileForm.confirmNewPassword")}
             name="confirmPassword"
             value={values.confirmPassword}
             onChange={onChange}
           />
+        </Form.Field>
+        <Form.Field>
+          <label>{t("languages.label")}</label>
+          <select name="preferredLanguage" value={values.preferredLanguage} onChange={onLanguageChange}>
+            <option value="en">{t("languages.en")}</option>
+            <option value="pt">{t("languages.pt")}</option>
+          </select>
         </Form.Field>
         <ProfilePictureSelector values={values} update />
         <Grid.Row
@@ -118,7 +132,7 @@ export function EditProfile() {
           }}
         >
           <Button type="submit" color="purple" size="big" onSubmit={onSubmit}>
-            Save Changes
+            {t("actions.saveChanges")}
           </Button>
         </Grid.Row>
       </Form>

--- a/apps/client/src/pages/ForgotPassword.tsx
+++ b/apps/client/src/pages/ForgotPassword.tsx
@@ -2,12 +2,14 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useMutation } from "@apollo/client/react";
 import { Button, Form, Message } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 
 import { REQUEST_PASSWORD_RESET } from "../util/GraphQL";
 import { getGraphQLErrors } from "../util/errors";
 import { useForm } from "../util/hooks";
 
 export default function ForgotPassword() {
+  const { t } = useTranslation();
   const [errors, setErrors] = useState({}) as any;
   const [successMessage, setSuccessMessage] = useState("");
   const { onChange, onSubmit, values } = useForm(onRequestReset, { email: "" });
@@ -43,11 +45,10 @@ export default function ForgotPassword() {
         className="page-title"
         style={{ marginBottom: "1em", marginTop: "1em" }}
       >
-        Forgot Password
+        {t("forgotPassword.title")}
       </h1>
       <p style={{ maxWidth: 480, textAlign: "center", marginBottom: "1.5em" }}>
-        Enter your email address and, if an account exists, you&apos;ll receive
-        a password reset link.
+        {t("forgotPassword.description")}
       </p>
       <Form
         onSubmit={onSubmit}
@@ -56,20 +57,20 @@ export default function ForgotPassword() {
         className={loading ? "loading" : ""}
       >
         <Form.Input
-          label="E-mail"
-          placeholder="E-mail"
+          label={t("common.email")}
+          placeholder={t("common.email")}
           name="email"
           value={values.email}
           onChange={onChange}
           error={errors?.email ? true : false}
         />
         <Button type="submit" primary>
-          Send Reset Link
+          {t("actions.sendResetLink")}
         </Button>
       </Form>
       {successMessage && (
         <Message positive style={{ marginTop: "1.5em", maxWidth: 480 }}>
-          <Message.Header>Check your email</Message.Header>
+          <Message.Header>{t("forgotPassword.checkEmail")}</Message.Header>
           <p>{successMessage}</p>
         </Message>
       )}
@@ -83,7 +84,7 @@ export default function ForgotPassword() {
         </div>
       )}
       <p style={{ marginTop: "1.5em" }}>
-        <Link to="/login">Back to login</Link>
+        <Link to="/login">{t("actions.backToLogin")}</Link>
       </p>
     </div>
   );

--- a/apps/client/src/pages/Home.tsx
+++ b/apps/client/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@apollo/client/react";
 import { useContext } from "react";
 import { Card, Container, Grid, Transition } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 import Ad from "../components/Ad";
 import NewPost from "../components/NewPost";
 import Post from "../components/Post";
@@ -9,6 +10,7 @@ import { FETCH_POSTS_QUERY } from "../util/GraphQL";
 import { Outlet } from "react-router-dom";
 
 function Home() {
+  const { t } = useTranslation();
   const { loading, data } = useQuery<any>(FETCH_POSTS_QUERY); //can't destructure here or else TS will scream
   const posts = data?.getPosts;
   const { user } = useContext(AuthContext);
@@ -17,7 +19,7 @@ function Home() {
     <Container>
       <Grid columns={3} stackable>
         <Grid.Row style={{ margin: "1rem 0" }}>
-          <h1 className="page-title">Recent Posts</h1>
+          <h1 className="page-title">{t("home.recentPosts")}</h1>
         </Grid.Row>
         <Outlet />
         <Grid.Row>
@@ -42,7 +44,7 @@ function Home() {
                 }}
               >
                 <h2 style={{ width: "100%" }}>
-                  Loading posts
+                  {t("home.loadingPosts")}
                   <img
                     src="spinner.svg"
                     alt=""

--- a/apps/client/src/pages/Login.tsx
+++ b/apps/client/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { Button, Form } from "semantic-ui-react";
 import { useState, useContext } from "react";
 import { useMutation } from "@apollo/client/react";
 import { Link, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 import { useForm } from "../util/hooks";
 import { AuthContext } from "../context/auth";
@@ -9,6 +10,7 @@ import { LOGIN_USER } from "../util/GraphQL";
 import { getGraphQLErrors } from "../util/errors";
 
 export default function Login() {
+  const { t } = useTranslation();
   const context = useContext(AuthContext);
   const navigate = useNavigate();
   const [errors, setErrors] = useState({}) as any;
@@ -47,7 +49,7 @@ export default function Login() {
         className="page-title"
         style={{ marginBottom: "2em", marginTop: "1em" }}
       >
-        Login
+        {t("actions.login")}
       </h1>
       <Form
         onSubmit={onSubmit}
@@ -56,8 +58,8 @@ export default function Login() {
         className={loading ? "loading" : ""}
       >
         <Form.Input
-          label="Username"
-          placeholder="Username"
+          label={t("common.username")}
+          placeholder={t("common.username")}
           name="username"
           value={values.username}
           onChange={onChange}
@@ -66,8 +68,8 @@ export default function Login() {
 
         <Form.Input
           type="password"
-          label="Password"
-          placeholder="Password"
+          label={t("common.password")}
+          placeholder={t("common.password")}
           name="password"
           value={values.password}
           onChange={onChange}
@@ -75,11 +77,11 @@ export default function Login() {
         />
 
         <Button type="submit" primary>
-          login
+          {t("actions.login")}
         </Button>
       </Form>
       <p style={{ marginTop: "1em" }}>
-        <Link to="/forgot-password">Forgot your password?</Link>
+        <Link to="/forgot-password">{t("forgotPassword.title")}</Link>
       </p>
       {errors && Object.keys(errors).length > 0 && (
         <div className="ui error message">

--- a/apps/client/src/pages/Register.test.tsx
+++ b/apps/client/src/pages/Register.test.tsx
@@ -60,6 +60,7 @@ describe('Register page', () => {
                 email: 'alice@example.com',
                 createdAt: '2026-04-23T00:00:00.000Z',
                 profilePicture: 'ade',
+                preferredLanguage: null,
                 token: 'signed-token',
                 __typename: 'User',
               },

--- a/apps/client/src/pages/Register.tsx
+++ b/apps/client/src/pages/Register.tsx
@@ -2,6 +2,7 @@ import { Form, Grid, Button } from "semantic-ui-react";
 import { useState, useContext } from "react";
 import { useMutation } from "@apollo/client/react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 import { useForm } from "../util/hooks";
 import { AuthContext } from "../context/auth";
@@ -11,6 +12,7 @@ import { getGraphQLErrors } from "../util/errors";
 import { ProfilePictureSelector } from "../atoms/ProfilePictureSelector";
 
 function Register() {
+  const { t } = useTranslation();
   const context = useContext(AuthContext);
   const navigate = useNavigate();
   const [errors, setErrors] = useState({}) as any;
@@ -55,7 +57,7 @@ function Register() {
         className="page-title"
         style={{ marginBottom: "2em", marginTop: "1em" }}
       >
-        Register
+        {t("register.title")}
       </h1>
       {Object.keys(errors)?.length > 0 && (
         <div className="ui error message">
@@ -79,16 +81,16 @@ function Register() {
       >
         <div>
           <Form.Input
-            label="Username"
-            placeholder="Username"
+            label={t("common.username")}
+            placeholder={t("common.username")}
             name="username"
             value={values.username}
             onChange={onChange}
             error={errors?.username ? true : false}
           />
           <Form.Input
-            label="E-mail"
-            placeholder="E-mail"
+            label={t("common.email")}
+            placeholder={t("common.email")}
             name="email"
             value={values.email}
             onChange={onChange}
@@ -96,8 +98,8 @@ function Register() {
           />
           <Form.Input
             type="password"
-            label="Password"
-            placeholder="Password"
+            label={t("common.password")}
+            placeholder={t("common.password")}
             name="password"
             value={values.password}
             onChange={onChange}
@@ -105,8 +107,8 @@ function Register() {
           />
           <Form.Input
             type="password"
-            label="Confirm Password"
-            placeholder="Confirm Password"
+            label={t("register.confirmPassword")}
+            placeholder={t("register.confirmPassword")}
             name="confirmPassword"
             value={values.confirmPassword}
             onChange={onChange}
@@ -123,7 +125,7 @@ function Register() {
           }}
         >
           <Button type="submit" color="purple" size="big">
-            Register
+            {t("register.title")}
           </Button>
         </Grid.Row>
       </Form>

--- a/apps/client/src/pages/ResetPassword.tsx
+++ b/apps/client/src/pages/ResetPassword.tsx
@@ -2,12 +2,14 @@ import { useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useMutation } from "@apollo/client/react";
 import { Button, Form, Message } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 
 import { RESET_PASSWORD } from "../util/GraphQL";
 import { getGraphQLErrors } from "../util/errors";
 import { useForm } from "../util/hooks";
 
 export default function ResetPassword() {
+  const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const [errors, setErrors] = useState({}) as any;
   const [successMessage, setSuccessMessage] = useState("");
@@ -35,7 +37,7 @@ export default function ResetPassword() {
   function onResetPassword() {
     if (!token) {
       setSuccessMessage("");
-      setErrors({ token: "Reset link is invalid or expired." });
+      setErrors({ token: t("resetPassword.invalidToken") });
       return;
     }
 
@@ -54,7 +56,7 @@ export default function ResetPassword() {
         className="page-title"
         style={{ marginBottom: "1em", marginTop: "1em" }}
       >
-        Reset Password
+        {t("resetPassword.title")}
       </h1>
       <Form
         onSubmit={onSubmit}
@@ -64,8 +66,8 @@ export default function ResetPassword() {
       >
         <Form.Input
           type="password"
-          label="New Password"
-          placeholder="New Password"
+          label={t("profileForm.newPassword")}
+          placeholder={t("profileForm.newPassword")}
           name="password"
           value={values.password}
           onChange={onChange}
@@ -73,23 +75,23 @@ export default function ResetPassword() {
         />
         <Form.Input
           type="password"
-          label="Confirm Password"
-          placeholder="Confirm Password"
+          label={t("register.confirmPassword")}
+          placeholder={t("register.confirmPassword")}
           name="confirmPassword"
           value={values.confirmPassword}
           onChange={onChange}
           error={errors?.confirmPassword ? true : false}
         />
         <Button type="submit" primary>
-          Reset Password
+          {t("actions.resetPassword")}
         </Button>
       </Form>
       {successMessage && (
         <Message positive style={{ marginTop: "1.5em", maxWidth: 480 }}>
-          <Message.Header>Password updated</Message.Header>
+          <Message.Header>{t("resetPassword.passwordUpdated")}</Message.Header>
           <p>{successMessage}</p>
           <p>
-            <Link to="/login">Go to login</Link>
+            <Link to="/login">{t("actions.goToLogin")}</Link>
           </p>
         </Message>
       )}

--- a/apps/client/src/pages/SinglePost.tsx
+++ b/apps/client/src/pages/SinglePost.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@apollo/client/react";
 import moment from "moment";
 import { useParams } from "react-router-dom";
 import { useContext } from "react";
+import { useTranslation } from "react-i18next";
 import spinner from "../atoms/3-dots-bounce.svg";
 import { Grid, Container, Card } from "semantic-ui-react";
 import { LikeButton } from "../atoms/LikeButton";
@@ -15,6 +16,7 @@ import { LikePictures } from "../atoms/LikePictures";
 import { Link, Outlet } from "react-router-dom";
 
 export default function SinglePost() {
+  const { t } = useTranslation();
   const { user } = useContext(AuthContext) as any;
 
   const { id } = useParams();
@@ -43,7 +45,7 @@ export default function SinglePost() {
         <h2
           style={{ width: "100%", display: "flex", justifyContent: "center" }}
         >
-          Loading post{" "}
+          {t("singlePost.loading")}{" "}
           <img
             src={spinner}
             style={{ position: "relative", top: ".5rem", left: ".5rem" }}
@@ -61,7 +63,7 @@ export default function SinglePost() {
                 padding: "3rem",
               }}
             >
-              Error! No post could be found.
+              {t("singlePost.notFound")}
             </h2>
           )}
           {post && (

--- a/apps/client/src/pages/User.tsx
+++ b/apps/client/src/pages/User.tsx
@@ -8,6 +8,7 @@ import {
   GridColumn,
   Button,
 } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 import { GET_USER_QUERY } from "../util/GraphQL";
 import { AuthContext } from "../context/auth";
 import { Link } from "react-router-dom";
@@ -15,13 +16,14 @@ import moment from "moment";
 import { getPictureURL } from "../util/profilePictureDictionary";
 
 export default function Profile({ username, setProfileState }) {
+  const { t } = useTranslation();
   const { user } = useContext(AuthContext) as any;
   const { loading, error, data } = useQuery<any>(GET_USER_QUERY, {
     variables: { username: username },
   });
 
   if (loading) return <Loader active />;
-  if (error) return <p>Error: {error.message}</p>;
+  if (error) return <p>{t("common.error", { message: error.message })}</p>;
 
   const { createdAt, profilePicture } = data.getUser;
   const isAuthUser = user?.username === username;
@@ -68,7 +70,7 @@ export default function Profile({ username, setProfileState }) {
               <Card.Header>{username}</Card.Header>
               <Card.Meta>
                 <span className="date">
-                  Joined {moment(createdAt).fromNow()}
+                  {t("profile.joined", { time: moment(createdAt).fromNow() })}
                 </span>
               </Card.Meta>
             </Card.Content>
@@ -83,7 +85,7 @@ export default function Profile({ username, setProfileState }) {
                     setProfileState(false);
                   }}
                 >
-                  Edit Profile
+                  {t("actions.editProfile")}
                 </Button>
               </Card.Content>
             )}

--- a/apps/client/src/test/test-utils.tsx
+++ b/apps/client/src/test/test-utils.tsx
@@ -7,6 +7,7 @@ import {
 } from "@apollo/client/testing/react";
 
 import { AuthContext } from "../context/auth";
+import "../i18n";
 
 interface RenderOptions {
   mocks?: MockedResponse[];

--- a/apps/client/src/util/GraphQL.tsx
+++ b/apps/client/src/util/GraphQL.tsx
@@ -65,6 +65,7 @@ export const LOGIN_USER = gql`
       username
       createdAt
       profilePicture
+      preferredLanguage
       token
     }
   }
@@ -104,6 +105,7 @@ export const REGISTER_USER = gql`
       email
       createdAt
       profilePicture
+      preferredLanguage
       token
     }
   }
@@ -218,6 +220,7 @@ export const GET_USER_QUERY = gql`
       email
       createdAt
       profilePicture
+      preferredLanguage
     }
   }
 `;
@@ -230,6 +233,21 @@ export const UPDATE_USER_MUTATION = gql`
       email
       createdAt
       profilePicture
+      preferredLanguage
+      token
+    }
+  }
+`;
+
+export const UPDATE_PREFERRED_LANGUAGE = gql`
+  mutation UpdatePreferredLanguage($preferredLanguage: String!) {
+    updatePreferredLanguage(preferredLanguage: $preferredLanguage) {
+      id
+      username
+      email
+      createdAt
+      profilePicture
+      preferredLanguage
       token
     }
   }
@@ -243,6 +261,7 @@ export const ME_QUERY = gql`
       email
       createdAt
       profilePicture
+      preferredLanguage
     }
   }
 `;

--- a/apps/server/graphql/generated.ts
+++ b/apps/server/graphql/generated.ts
@@ -46,6 +46,7 @@ export type Mutation = {
   register: User;
   requestPasswordReset: PasswordResetResponse;
   resetPassword: PasswordResetResponse;
+  updatePreferredLanguage: User;
   updateUser: User;
 };
 
@@ -97,6 +98,11 @@ export type MutationResetPasswordArgs = {
   confirmPassword: Scalars['String']['input'];
   password: Scalars['String']['input'];
   token: Scalars['String']['input'];
+};
+
+
+export type MutationUpdatePreferredLanguageArgs = {
+  preferredLanguage: Scalars['String']['input'];
 };
 
 
@@ -157,6 +163,7 @@ export type UpdateProfileInput = {
   newUsername: Scalars['String']['input'];
   oldPassword: Scalars['String']['input'];
   oldUsername: Scalars['String']['input'];
+  preferredLanguage?: InputMaybe<Scalars['String']['input']>;
   profilePicture: Scalars['String']['input'];
 };
 
@@ -165,6 +172,7 @@ export type User = {
   createdAt: Scalars['String']['output'];
   email: Scalars['String']['output'];
   id: Scalars['ID']['output'];
+  preferredLanguage?: Maybe<Scalars['String']['output']>;
   profilePicture: Scalars['String']['output'];
   token?: Maybe<Scalars['String']['output']>;
   username: Scalars['String']['output'];
@@ -301,6 +309,7 @@ export type MutationResolvers<ContextType = GraphQLContext, ParentType extends R
   register?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationRegisterArgs, 'registerInput'>>;
   requestPasswordReset?: Resolver<ResolversTypes['PasswordResetResponse'], ParentType, ContextType, RequireFields<MutationRequestPasswordResetArgs, 'email'>>;
   resetPassword?: Resolver<ResolversTypes['PasswordResetResponse'], ParentType, ContextType, RequireFields<MutationResetPasswordArgs, 'confirmPassword' | 'password' | 'token'>>;
+  updatePreferredLanguage?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdatePreferredLanguageArgs, 'preferredLanguage'>>;
   updateUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdateUserArgs, 'updateProfileInput'>>;
 };
 
@@ -333,6 +342,7 @@ export type UserResolvers<ContextType = GraphQLContext, ParentType extends Resol
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  preferredLanguage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   profilePicture?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   username?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -347,3 +357,4 @@ export type Resolvers<ContextType = GraphQLContext> = {
   Query?: QueryResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };
+

--- a/apps/server/graphql/resolvers/users.ts
+++ b/apps/server/graphql/resolvers/users.ts
@@ -45,6 +45,7 @@ interface UpdateProfileInput {
   newPassword?: string;
   confirmPassword?: string;
   profilePicture?: string;
+  preferredLanguage?: string | null;
 }
 
 interface UpdateProfileArgs {
@@ -65,6 +66,10 @@ interface ResetPasswordArgs {
   confirmPassword: string;
 }
 
+interface UpdatePreferredLanguageArgs {
+  preferredLanguage: string;
+}
+
 const PASSWORD_RESET_TTL_MS = 1000 * 60 * 30;
 const PASSWORD_RESET_ACCOUNT_WINDOW_MS = 1000 * 60 * 15;
 const PASSWORD_RESET_ACCOUNT_MAX_REQUESTS = 3;
@@ -74,6 +79,7 @@ const PASSWORD_RESET_SUCCESS_MESSAGE =
   "If an account exists for that email, a password reset link has been sent.";
 const PASSWORD_RESET_COMPLETED_MESSAGE =
   "Your password has been reset. You can now log in with the new password.";
+const SUPPORTED_LANGUAGES = new Set(["en", "pt"]);
 
 function hashResetToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
@@ -345,6 +351,7 @@ const usersResolvers = {
           newPassword,
           confirmPassword,
           profilePicture,
+          preferredLanguage,
         },
       }: UpdateProfileArgs
     ) {
@@ -439,10 +446,52 @@ const usersResolvers = {
         user.profilePicture = profilePicture;
       }
 
+      if (preferredLanguage !== undefined && preferredLanguage !== null) {
+        if (!SUPPORTED_LANGUAGES.has(preferredLanguage)) {
+          throw createUserInputError("Unsupported language.", {
+            errors: {
+              preferredLanguage: "Unsupported language.",
+            },
+          });
+        }
+
+        user.preferredLanguage = preferredLanguage;
+      }
+
       const res = await user.save();
       const token = generateToken(res);
 
       return { ...toPublicUser(res), token };
+    },
+
+    async updatePreferredLanguage(
+      _: unknown,
+      { preferredLanguage }: UpdatePreferredLanguageArgs,
+      context: GraphQLContext
+    ) {
+      if (!SUPPORTED_LANGUAGES.has(preferredLanguage)) {
+        throw createUserInputError("Unsupported language.", {
+          errors: {
+            preferredLanguage: "Unsupported language.",
+          },
+        });
+      }
+
+      const { username } = checkAuth(context);
+      const user = await User.findOne({ username });
+
+      if (!user) {
+        throw createUserInputError("User not found.", {
+          errors: {
+            username: "User not found.",
+          },
+        });
+      }
+
+      user.preferredLanguage = preferredLanguage;
+      const res = await user.save();
+
+      return toPublicUser(res);
     },
   },
 

--- a/apps/server/graphql/schema.graphql
+++ b/apps/server/graphql/schema.graphql
@@ -41,6 +41,7 @@ input UpdateProfileInput {
   newPassword: String!
   confirmPassword: String!
   profilePicture: String!
+  preferredLanguage: String
 }
 
 type PasswordResetResponse {
@@ -62,6 +63,7 @@ type User {
   email: String!
   createdAt: String!
   profilePicture: String!
+  preferredLanguage: String
   token: String
 }
 
@@ -81,4 +83,5 @@ type Mutation {
   deleteComment(postId: String!, commentId: String!): Post!
   likePost(postId: ID!): Post!
   updateUser(updateProfileInput: UpdateProfileInput!): User!
+  updatePreferredLanguage(preferredLanguage: String!): User!
 }

--- a/apps/server/lib/auth.ts
+++ b/apps/server/lib/auth.ts
@@ -55,6 +55,7 @@ export function toPublicUser(user: UserDocument | PublicUser): PublicUser {
     email: user.email,
     createdAt: user.createdAt,
     profilePicture: user.profilePicture,
+    preferredLanguage: user.preferredLanguage ?? null,
     token,
   };
 }

--- a/apps/server/models/User.ts
+++ b/apps/server/models/User.ts
@@ -8,6 +8,7 @@ const userSchema = new Schema<UserShape>({
   email: String,
   createdAt: String,
   profilePicture: String,
+  preferredLanguage: String,
   passwordResetTokenHash: String,
   passwordResetExpiresAt: String,
   passwordResetRequestedAt: String,

--- a/apps/server/types.ts
+++ b/apps/server/types.ts
@@ -24,6 +24,7 @@ export interface PublicUser {
   email: string;
   createdAt: string;
   profilePicture: string;
+  preferredLanguage?: string | null;
   token?: string | null;
 }
 
@@ -33,6 +34,7 @@ export interface UserShape {
   email: string;
   createdAt: string;
   profilePicture: string;
+  preferredLanguage?: string | null;
   passwordResetTokenHash?: string | null;
   passwordResetExpiresAt?: string | null;
   passwordResetRequestedAt?: string | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       graphql-tag:
         specifier: ^2.12.6
         version: 2.12.6(graphql@16.13.2)
+      i18next:
+        specifier: ^26.0.8
+        version: 26.0.8(typescript@5.9.3)
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
@@ -80,6 +83,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-i18next:
+        specifier: ^17.0.6
+        version: 17.0.6(i18next@26.0.8(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react-router-dom:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2861,6 +2867,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2884,6 +2893,14 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  i18next@26.0.8:
+    resolution: {integrity: sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3561,6 +3578,22 @@ packages:
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
+  react-i18next@17.0.6:
+    resolution: {integrity: sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==}
+    peerDependencies:
+      i18next: '>= 26.0.1'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -4022,6 +4055,11 @@ packages:
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -4110,6 +4148,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -7492,6 +7534,10 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7530,6 +7576,10 @@ snapshots:
       - supports-color
 
   husky@9.1.7: {}
+
+  i18next@26.0.8(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   iconv-lite@0.4.24:
     dependencies:
@@ -8154,6 +8204,17 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
+  react-i18next@17.0.6(i18next@26.0.8(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      html-parse-stringify: 3.0.1
+      i18next: 26.0.8(typescript@5.9.3)
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+      typescript: 5.9.3
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -8662,6 +8723,10 @@ snapshots:
 
   urlpattern-polyfill@10.1.0: {}
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   utils-merge@1.0.1: {}
 
   uuid@9.0.1: {}
@@ -8748,6 +8813,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
### What changed
- Added `i18next` and `react-i18next` with English and Portuguese resources.
- Initialized i18n from stored preference, then browser/OS language, with English fallback.
- Disabled React i18next Suspense via `react.useSuspense: false`.
- Added a language selector in the Semantic UI menu; anonymous users persist locally and authenticated users persist to their account.
- Added `preferredLanguage` to the user model, public auth shape, GraphQL schemas, generated types, and user resolvers while preserving the existing `token` field on auth responses.
- Added `updatePreferredLanguage` for lightweight language persistence without requiring a password-backed profile update.
- Localized the main auth, profile, post, comment, dialog, and navigation UI text on the current `main` UI.

### Impact
Users can choose English or Portuguese. If they do not choose, the client follows the browser/OS language where supported.

### Validation
- `pnpm --filter @hiworld/client typecheck`
- `pnpm --filter @hiworld/server typecheck`
- `pnpm schema:check`
- `pnpm --filter @hiworld/client lint`
- `pnpm --filter @hiworld/client test`
- `pnpm --filter @hiworld/server test`
- `pnpm --filter @hiworld/client build`

Note: this replaces the earlier stacked PR against the shadcn migration branch.