### PR TITLE
[codex] Fix i18n language controls and locale files

### DIFF
--- a/apps/client/src/components/MenuBar.tsx
+++ b/apps/client/src/components/MenuBar.tsx
@@ -1,10 +1,10 @@
-import { useState, useContext, type ChangeEvent } from "react";
+import { useState, useContext } from "react";
 import { useApolloClient } from "@apollo/client/react";
 import { useMutation } from "@apollo/client/react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
-import { Image, Menu, MenuItemProps } from "semantic-ui-react";
+import { Dropdown, Image, Menu, MenuItemProps, type DropdownProps } from "semantic-ui-react";
 import { AuthContext } from "../context/auth";
 import { LOGOUT_USER, ME_QUERY, UPDATE_PREFERRED_LANGUAGE } from "../util/GraphQL";
 import { getPictureURL } from "../util/profilePictureDictionary";
@@ -41,9 +41,13 @@ export default function MenuBar() {
   const [updatePreferredLanguage] = useMutation<any>(UPDATE_PREFERRED_LANGUAGE, {
     onCompleted: ({ updatePreferredLanguage: userData }) => login(userData),
   });
+  const languageOptions = [
+    { key: "en", text: t("languages.en"), value: "en" },
+    { key: "pt", text: t("languages.pt"), value: "pt" },
+  ];
 
-  function onLanguageChange(event: ChangeEvent<HTMLSelectElement>) {
-    const preferredLanguage = event.target.value as SupportedLanguage;
+  function onLanguageChange(_: React.SyntheticEvent<HTMLElement>, data: DropdownProps) {
+    const preferredLanguage = data.value as SupportedLanguage;
     setPreferredLanguage(preferredLanguage);
     if (user) {
       void updatePreferredLanguage({ variables: { preferredLanguage } });
@@ -69,10 +73,14 @@ export default function MenuBar() {
         <Menu.Item>
           <label style={{ display: "flex", alignItems: "center", gap: ".5rem" }}>
             <span>{t("languages.label")}</span>
-            <select aria-label={t("languages.label")} value={i18n.language.startsWith("pt") ? "pt" : "en"} onChange={onLanguageChange}>
-              <option value="en">{t("languages.en")}</option>
-              <option value="pt">{t("languages.pt")}</option>
-            </select>
+            <Dropdown
+              aria-label={t("languages.label")}
+              compact
+              onChange={onLanguageChange}
+              options={languageOptions}
+              selection
+              value={i18n.language.startsWith("pt") ? "pt" : "en"}
+            />
           </label>
         </Menu.Item>
         <Menu.Item
@@ -130,10 +138,14 @@ export default function MenuBar() {
         <Menu.Item>
           <label style={{ display: "flex", alignItems: "center", gap: ".5rem" }}>
             <span>{t("languages.label")}</span>
-            <select aria-label={t("languages.label")} value={i18n.language.startsWith("pt") ? "pt" : "en"} onChange={onLanguageChange}>
-              <option value="en">{t("languages.en")}</option>
-              <option value="pt">{t("languages.pt")}</option>
-            </select>
+            <Dropdown
+              aria-label={t("languages.label")}
+              compact
+              onChange={onLanguageChange}
+              options={languageOptions}
+              selection
+              value={i18n.language.startsWith("pt") ? "pt" : "en"}
+            />
           </label>
         </Menu.Item>
         <Menu.Item

--- a/apps/client/src/i18n.ts
+++ b/apps/client/src/i18n.ts
@@ -1,7 +1,10 @@
 import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
 import moment from "moment";
 import "moment/dist/locale/pt-br";
+import { initReactI18next } from "react-i18next";
+
+import en from "./locales/en.json";
+import pt from "./locales/pt.json";
 
 export const LANGUAGE_STORAGE_KEY = "hiworld.preferredLanguage";
 export const SUPPORTED_LANGUAGES = ["en", "pt"] as const;
@@ -34,207 +37,6 @@ function setMomentLocale(language: SupportedLanguage) {
   moment.locale(language === "pt" ? "pt-br" : "en");
 }
 
-const resources = {
-  en: {
-    translation: {
-      actions: {
-        addComment: "Add Comment",
-        backToLogin: "Back to login",
-        cancel: "Cancel",
-        confirm: "Confirm",
-        commentOnPost: "Comment on post",
-        editProfile: "Edit Profile",
-        goToLogin: "Go to login",
-        login: "login",
-        logout: "logout",
-        likePost: "Like Post",
-        register: "register",
-        resetPassword: "Reset Password",
-        saveChanges: "Save Changes",
-        send: "Send",
-        sendResetLink: "Send Reset Link",
-      },
-      comments: {
-        count_one: "{{count}} Comment",
-        count_other: "{{count}} Comments",
-      },
-      common: {
-        email: "E-mail",
-        error: "Error: {{message}}",
-        loading: "Loading...",
-        password: "Password",
-        username: "Username",
-      },
-      dialogs: {
-        deleteComment: "Delete comment",
-        deletePost: "Delete post",
-        destructiveDescription: "This action cannot be undone.",
-      },
-      forgotPassword: {
-        checkEmail: "Check your email",
-        description: "Enter your email address and, if an account exists, you'll receive a password reset link.",
-        title: "Forgot Password",
-      },
-      home: {
-        loadingPosts: "Loading posts",
-        recentPosts: "Recent Posts",
-      },
-      languages: {
-        en: "English",
-        label: "Language",
-        pt: "Portuguese",
-      },
-      likes: {
-        and: "and",
-        likedBy: "{{names}} liked this.",
-        likedThisPlural: "liked this.",
-        likedThisSingular: "liked this.",
-        nobody: "Nobody Liked This",
-        others_one: "{{count}} other person",
-        others_other: "{{count}} other people",
-        you: "You",
-        youLiked: "You liked this.",
-      },
-      newComment: {
-        error: "Could not add comment.",
-        placeholder: "Add your comment",
-      },
-      newPost: {
-        errorSuffix: "!",
-        placeholder: "Say hi to the World!",
-        title: "New Post",
-      },
-      profile: {
-        selectAvatar: "Select an Avatar",
-        selectNewAvatar: "Select a new Avatar",
-        joined: "Joined {{time}}",
-      },
-      profileForm: {
-        confirmNewPassword: "Confirm New Password",
-        newPassword: "New Password",
-        newUsername: "New Username (Leave Blank if you don't want to change it)",
-        oldPassword: "Old Password",
-        title: "Edit Profile",
-      },
-      register: {
-        confirmPassword: "Confirm Password",
-        title: "Register",
-      },
-      resetPassword: {
-        invalidToken: "Reset link is invalid or expired.",
-        passwordUpdated: "Password updated",
-        title: "Reset Password",
-      },
-      singlePost: {
-        loading: "Loading post",
-        notFound: "Error! No post could be found.",
-      },
-      welcome: {
-        ad: "See what our users are talking about right now!",
-      },
-    },
-  },
-  pt: {
-    translation: {
-      actions: {
-        addComment: "Adicionar comentario",
-        backToLogin: "Voltar ao login",
-        cancel: "Cancelar",
-        confirm: "Confirmar",
-        commentOnPost: "Comentar na publicacao",
-        editProfile: "Editar perfil",
-        goToLogin: "Ir para o login",
-        login: "entrar",
-        logout: "sair",
-        likePost: "Curtir publicacao",
-        register: "cadastrar",
-        resetPassword: "Redefinir senha",
-        saveChanges: "Salvar alteracoes",
-        send: "Enviar",
-        sendResetLink: "Enviar link de redefinicao",
-      },
-      comments: {
-        count_one: "{{count}} Comentario",
-        count_other: "{{count}} Comentarios",
-      },
-      common: {
-        email: "E-mail",
-        error: "Erro: {{message}}",
-        loading: "Carregando...",
-        password: "Senha",
-        username: "Nome de usuario",
-      },
-      dialogs: {
-        deleteComment: "Excluir comentario",
-        deletePost: "Excluir publicacao",
-        destructiveDescription: "Esta acao nao pode ser desfeita.",
-      },
-      forgotPassword: {
-        checkEmail: "Verifique seu e-mail",
-        description: "Informe seu e-mail e, se existir uma conta, voce recebera um link para redefinir a senha.",
-        title: "Esqueci minha senha",
-      },
-      home: {
-        loadingPosts: "Carregando publicacoes",
-        recentPosts: "Publicacoes recentes",
-      },
-      languages: {
-        en: "Ingles",
-        label: "Idioma",
-        pt: "Portugues",
-      },
-      likes: {
-        and: "e",
-        likedBy: "{{names}} curtiram isto.",
-        likedThisPlural: "curtiram isto.",
-        likedThisSingular: "curtiu isto.",
-        nobody: "Ninguem curtiu isto",
-        others_one: "{{count}} outra pessoa",
-        others_other: "{{count}} outras pessoas",
-        you: "Voce",
-        youLiked: "Voce curtiu isto.",
-      },
-      newComment: {
-        error: "Nao foi possivel adicionar o comentario.",
-        placeholder: "Adicione seu comentario",
-      },
-      newPost: {
-        errorSuffix: "!",
-        placeholder: "Diga oi ao mundo!",
-        title: "Nova publicacao",
-      },
-      profile: {
-        selectAvatar: "Selecione um avatar",
-        selectNewAvatar: "Selecione um novo avatar",
-        joined: "Entrou {{time}}",
-      },
-      profileForm: {
-        confirmNewPassword: "Confirmar nova senha",
-        newPassword: "Nova senha",
-        newUsername: "Novo nome de usuario (deixe em branco se nao quiser alterar)",
-        oldPassword: "Senha atual",
-        title: "Editar perfil",
-      },
-      register: {
-        confirmPassword: "Confirmar senha",
-        title: "Cadastro",
-      },
-      resetPassword: {
-        invalidToken: "O link de redefinicao e invalido ou expirou.",
-        passwordUpdated: "Senha atualizada",
-        title: "Redefinir senha",
-      },
-      singlePost: {
-        loading: "Carregando publicacao",
-        notFound: "Erro! Nenhuma publicacao foi encontrada.",
-      },
-      welcome: {
-        ad: "Veja o que nossos usuarios estao falando agora!",
-      },
-    },
-  },
-};
-
 i18n.use(initReactI18next).init({
   fallbackLng: "en",
   interpolation: {
@@ -244,7 +46,14 @@ i18n.use(initReactI18next).init({
   react: {
     useSuspense: false,
   },
-  resources,
+  resources: {
+    en: {
+      translation: en,
+    },
+    pt: {
+      translation: pt,
+    },
+  },
 });
 
 setMomentLocale(i18n.language === "pt" ? "pt" : "en");

--- a/apps/client/src/locales/en.json
+++ b/apps/client/src/locales/en.json
@@ -1,0 +1,97 @@
+{
+  "actions": {
+    "addComment": "Add Comment",
+    "backToLogin": "Back to login",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "commentOnPost": "Comment on post",
+    "editProfile": "Edit Profile",
+    "goToLogin": "Go to login",
+    "likePost": "Like Post",
+    "login": "login",
+    "logout": "logout",
+    "register": "register",
+    "resetPassword": "Reset Password",
+    "saveChanges": "Save Changes",
+    "send": "Send",
+    "sendResetLink": "Send Reset Link"
+  },
+  "comments": {
+    "count_one": "{{count}} Comment",
+    "count_other": "{{count}} Comments"
+  },
+  "common": {
+    "email": "E-mail",
+    "error": "Error: {{message}}",
+    "loading": "Loading...",
+    "password": "Password",
+    "username": "Username"
+  },
+  "dialogs": {
+    "deleteComment": "Delete comment",
+    "deletePost": "Delete post",
+    "destructiveDescription": "This action cannot be undone."
+  },
+  "forgotPassword": {
+    "checkEmail": "Check your email",
+    "description": "Enter your email address and, if an account exists, you'll receive a password reset link.",
+    "title": "Forgot Password"
+  },
+  "home": {
+    "loadingPosts": "Loading posts",
+    "recentPosts": "Recent Posts"
+  },
+  "languages": {
+    "en": "English",
+    "label": "Language",
+    "pt": "Portuguese"
+  },
+  "likes": {
+    "and": "and",
+    "likedBy": "{{names}} liked this.",
+    "likedThisPlural": "liked this.",
+    "likedThisSingular": "liked this.",
+    "nobody": "Nobody Liked This",
+    "others_one": "{{count}} other person",
+    "others_other": "{{count}} other people",
+    "you": "You",
+    "youLiked": "You liked this."
+  },
+  "newComment": {
+    "error": "Could not add comment.",
+    "placeholder": "Add your comment"
+  },
+  "newPost": {
+    "errorSuffix": "!",
+    "placeholder": "Say hi to the World!",
+    "title": "New Post"
+  },
+  "profile": {
+    "joined": "Joined {{time}}",
+    "selectAvatar": "Select an Avatar",
+    "selectNewAvatar": "Select a new Avatar"
+  },
+  "profileForm": {
+    "confirmNewPassword": "Confirm New Password",
+    "newPassword": "New Password",
+    "newUsername": "New Username (Leave Blank if you don't want to change it)",
+    "oldPassword": "Old Password",
+    "title": "Edit Profile"
+  },
+  "register": {
+    "confirmPassword": "Confirm Password",
+    "title": "Register"
+  },
+  "resetPassword": {
+    "invalidToken": "Reset link is invalid or expired.",
+    "passwordUpdated": "Password updated",
+    "title": "Reset Password"
+  },
+  "singlePost": {
+    "loading": "Loading post",
+    "notFound": "Error! No post could be found."
+  },
+  "welcome": {
+    "ad": "See what our users are talking about right now!"
+  }
+}

--- a/apps/client/src/locales/pt.json
+++ b/apps/client/src/locales/pt.json
@@ -1,0 +1,97 @@
+{
+  "actions": {
+    "addComment": "Adicionar comentário",
+    "backToLogin": "Voltar ao login",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "commentOnPost": "Comentar na publicação",
+    "editProfile": "Editar perfil",
+    "goToLogin": "Ir para o login",
+    "likePost": "Curtir publicação",
+    "login": "entrar",
+    "logout": "sair",
+    "register": "cadastrar",
+    "resetPassword": "Redefinir senha",
+    "saveChanges": "Salvar alterações",
+    "send": "Enviar",
+    "sendResetLink": "Enviar link de redefinição"
+  },
+  "comments": {
+    "count_one": "{{count}} Comentário",
+    "count_other": "{{count}} Comentários"
+  },
+  "common": {
+    "email": "E-mail",
+    "error": "Erro: {{message}}",
+    "loading": "Carregando...",
+    "password": "Senha",
+    "username": "Nome de usuário"
+  },
+  "dialogs": {
+    "deleteComment": "Excluir comentário",
+    "deletePost": "Excluir publicação",
+    "destructiveDescription": "Esta ação não pode ser desfeita."
+  },
+  "forgotPassword": {
+    "checkEmail": "Verifique seu e-mail",
+    "description": "Informe seu e-mail e, se existir uma conta, você receberá um link para redefinir a senha.",
+    "title": "Esqueci minha senha"
+  },
+  "home": {
+    "loadingPosts": "Carregando publicações",
+    "recentPosts": "Publicações recentes"
+  },
+  "languages": {
+    "en": "Inglês",
+    "label": "Idioma",
+    "pt": "Português"
+  },
+  "likes": {
+    "and": "e",
+    "likedBy": "{{names}} curtiram isto.",
+    "likedThisPlural": "curtiram isto.",
+    "likedThisSingular": "curtiu isto.",
+    "nobody": "Ninguém curtiu isto",
+    "others_one": "{{count}} outra pessoa",
+    "others_other": "{{count}} outras pessoas",
+    "you": "Você",
+    "youLiked": "Você curtiu isto."
+  },
+  "newComment": {
+    "error": "Não foi possível adicionar o comentário.",
+    "placeholder": "Adicione seu comentário"
+  },
+  "newPost": {
+    "errorSuffix": "!",
+    "placeholder": "Diga oi ao mundo!",
+    "title": "Nova publicação"
+  },
+  "profile": {
+    "joined": "Entrou {{time}}",
+    "selectAvatar": "Selecione um avatar",
+    "selectNewAvatar": "Selecione um novo avatar"
+  },
+  "profileForm": {
+    "confirmNewPassword": "Confirmar nova senha",
+    "newPassword": "Nova senha",
+    "newUsername": "Novo nome de usuário (deixe em branco se não quiser alterar)",
+    "oldPassword": "Senha atual",
+    "title": "Editar perfil"
+  },
+  "register": {
+    "confirmPassword": "Confirmar senha",
+    "title": "Cadastro"
+  },
+  "resetPassword": {
+    "invalidToken": "O link de redefinição é inválido ou expirou.",
+    "passwordUpdated": "Senha atualizada",
+    "title": "Redefinir senha"
+  },
+  "singlePost": {
+    "loading": "Carregando publicação",
+    "notFound": "Erro! Nenhuma publicação foi encontrada."
+  },
+  "welcome": {
+    "ad": "Veja o que nossos usuários estão falando agora!"
+  }
+}

--- a/apps/client/src/pages/EditProfile.tsx
+++ b/apps/client/src/pages/EditProfile.tsx
@@ -1,5 +1,5 @@
-import { useState, useContext, type ChangeEvent } from "react";
-import { Form, Button, Container, Grid, Loader } from "semantic-ui-react";
+import { useState, useContext } from "react";
+import { Form, Button, Container, Dropdown, Grid, Loader, type DropdownProps } from "semantic-ui-react";
 import { useTranslation } from "react-i18next";
 import { useForm } from "../util/hooks";
 import { useMutation } from "@apollo/client/react";
@@ -47,9 +47,20 @@ export function EditProfile() {
     changeUser();
   }
 
-  function onLanguageChange(e: ChangeEvent<HTMLSelectElement>) {
-    onChange(e);
-    setPreferredLanguage(e.target.value as SupportedLanguage);
+  const languageOptions = [
+    { key: "en", text: t("languages.en"), value: "en" },
+    { key: "pt", text: t("languages.pt"), value: "pt" },
+  ];
+
+  function onLanguageChange(_: React.SyntheticEvent<HTMLElement>, data: DropdownProps) {
+    const preferredLanguage = data.value as SupportedLanguage;
+    onChange({
+      target: {
+        name: "preferredLanguage",
+        value: preferredLanguage,
+      },
+    });
+    setPreferredLanguage(preferredLanguage);
   }
 
   return loading ? (
@@ -118,10 +129,13 @@ export function EditProfile() {
         </Form.Field>
         <Form.Field>
           <label>{t("languages.label")}</label>
-          <select name="preferredLanguage" value={values.preferredLanguage} onChange={onLanguageChange}>
-            <option value="en">{t("languages.en")}</option>
-            <option value="pt">{t("languages.pt")}</option>
-          </select>
+          <Dropdown
+            name="preferredLanguage"
+            onChange={onLanguageChange}
+            options={languageOptions}
+            selection
+            value={values.preferredLanguage}
+          />
         </Form.Field>
         <ProfilePictureSelector values={values} update />
         <Grid.Row


### PR DESCRIPTION
### What changed
- Replaced native language `<select>` controls with Semantic UI `Dropdown` components in the menu and edit-profile language field.
- Moved translation resources out of `i18n.ts` into `apps/client/src/locales/en.json` and `apps/client/src/locales/pt.json`.
- Added proper Portuguese accentuation across the `pt` locale strings.

### Validation
- `pnpm --filter @hiworld/client typecheck`
- `pnpm --filter @hiworld/client lint`
- `pnpm --filter @hiworld/client test`
- `pnpm --filter @hiworld/client build`