### PR TITLE
[codex] add scoped agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Instructions
+
+## Scope
+
+This file is for repo-wide guidance only. Put client-specific instructions in `apps/client/AGENTS.md` and server-specific instructions in `apps/server/AGENTS.md`.
+
+## Workspace
+
+- Use `pnpm` for all package operations. The pinned package manager is `pnpm@10.33.2`, and Node is expected to be `24` (`.node-version`, `package.json` engines).
+- Run commands from the repo root unless you are intentionally working inside one workspace. Workspaces are declared as `apps/*`.
+- Respect workspace boundaries: add app-only code and dependencies to that app, and make shared/root changes only when they affect more than one workspace.
+- Prefer workspace-specific dependencies when only one app needs them, for example `pnpm --filter @hiworld/client add ...` or `pnpm --filter @hiworld/server add ...`.
+- Keep `pnpm-lock.yaml` changes intentional and tied to the dependency change being made.
+
+## Repo Commands
+
+- `pnpm dev` runs Turbo dev tasks in parallel.
+- `pnpm build`, `pnpm lint`, `pnpm typecheck`, and `pnpm test` run the matching Turbo task across workspaces.
+- `pnpm check` runs lint, typecheck, and tests.
+- `pnpm schema:export` exports the server schema to the client schema file.
+- `pnpm schema:check` verifies `apps/client/src/graphql/schema.graphql` matches the server schema.
+- CI installs with `pnpm install --frozen-lockfile --ignore-scripts`, then runs lint, typecheck, schema check, tests, and build.
+
+## Local Development
+
+- Docker Compose is for local development only. It runs MongoDB, Mailpit, the server, the client, and the Nginx dev proxy.
+- Browser-facing local domains use `.social`, not `.local`; keep new local hostnames consistent with `hiworld.social`, `server.hiworld.social`, and `mail.hiworld.social`.
+
+## Environment
+
+- Do not commit real secrets.
+- When adding required environment variables, update the appropriate app-level `.env.example` and nearby docs/config that describe that app.

--- a/apps/client/AGENTS.md
+++ b/apps/client/AGENTS.md
@@ -1,0 +1,34 @@
+# Client Instructions
+
+## Scope
+
+This file applies only to `apps/client`. See the root `AGENTS.md` for workspace-level commands and dependency policy.
+
+## Commands
+
+- `pnpm --filter @hiworld/client dev` starts Vite on `0.0.0.0` port `3000`.
+- `pnpm --filter @hiworld/client build` runs `tsc -p tsconfig.json` and `vite build`.
+- `pnpm --filter @hiworld/client test` runs Vitest.
+- `pnpm --filter @hiworld/client lint` runs ESLint over `src`.
+- `pnpm --filter @hiworld/client typecheck` runs `tsc --noEmit`.
+- `pnpm --filter @hiworld/client preview` serves the production build with Vite preview.
+
+## App Conventions
+
+- This is a React 18 app built with Vite and `@vitejs/plugin-react`.
+- The React entrypoint is `src/index.tsx`; routing lives in `src/App.tsx` with `react-router-dom`.
+- Apollo Client is configured in `src/ApolloProvider.tsx`; shared GraphQL documents currently live in `src/util/GraphQL.tsx`.
+- Authentication UI state is managed through `src/context/auth.tsx` and route gating through `src/util/AuthRoute.tsx`.
+- Styling is centered in `src/App.css`, with small reusable UI primitives under `src/components/ui` using the local `cn` helper from `src/lib/utils.ts`.
+- Tests use Vitest with `jsdom`, `src/setupTests.ts`, and React Testing Library helpers under `src/test`.
+
+## Environment
+
+- Vite exposes only configured prefixes: `VITE_` and `REACT_APP_`.
+- `VITE_GRAPHQL_ENDPOINT` is documented in `.env.example` and read by the Apollo provider.
+- Dev-server HMR can be adjusted with `VITE_HMR_HOST` and `VITE_HMR_CLIENT_PORT`.
+
+## Deployment
+
+- The client builds to Vite's `dist` output and is the workspace intended for frontend deployment.
+- If configuring Vercel for this app, point the project root at `apps/client` or use equivalent settings that run this workspace's build.

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -1,0 +1,45 @@
+# Server Instructions
+
+## Scope
+
+This file applies only to `apps/server`. See the root `AGENTS.md` for workspace-level commands and dependency policy.
+
+## Commands
+
+- `pnpm --filter @hiworld/server dev` runs `tsx watch --clear-screen=false index.ts`.
+- `pnpm --filter @hiworld/server build` bundles `index.ts` with esbuild for Node 24 and writes `dist/index.cjs`.
+- `pnpm --filter @hiworld/server start` runs `node dist/index.cjs`.
+- `pnpm --filter @hiworld/server test` runs Vitest.
+- `pnpm --filter @hiworld/server lint` runs ESLint over TypeScript files.
+- `pnpm --filter @hiworld/server typecheck` runs `tsc --noEmit`.
+- `pnpm --filter @hiworld/server db:setup` creates required MongoDB collections for the configured database.
+- `pnpm --filter @hiworld/server codegen` regenerates `graphql/generated.ts`.
+- `pnpm --filter @hiworld/server export-schema` writes the exported schema used by the client schema check.
+
+## Runtime And Build
+
+- Source uses ESM TypeScript (`"type": "module"`, `moduleResolution: "Bundler"`), but production output is bundled CommonJS at `dist/index.cjs`.
+- The build also copies `graphql/schema.graphql` to `dist/graphql/schema.graphql`; keep that path working when changing schema loading.
+- Production startup should rely on the built Node artifact and environment variables, not on a Docker-only path.
+
+## GraphQL And Data
+
+- `index.ts` loads env, connects Mongoose, then starts the Apollo/Express app from `server.ts`.
+- `server.ts` creates the Apollo Server, Express middleware, CORS config, and GraphQL context containing optional `req` and `res`.
+- Schema text lives in `graphql/schema.graphql`; `graphql/typeDefs.ts` loads it for runtime.
+- Resolver modules live under `graphql/resolvers`, with `graphql/resolvers/index.ts` composing Query and Mutation maps.
+- Mongoose models live under `models`; shared GraphQL/domain types live in `types.ts`.
+- Generated resolver types in `graphql/generated.ts` are codegen output and are ignored by ESLint.
+
+## Environment And Auth
+
+- `MONGODB_URI` is required at startup; `MONGODB` is accepted as a fallback.
+- `SECRET_KEY` is required before creating the Apollo server.
+- Email and password-reset settings are documented in `.env.example`, including `PASSWORD_RESET_URL_BASE`, `EMAIL_TRANSPORT`, SMTP settings, and Resend settings.
+- CORS allowed origins are defined in `server.ts` from `CLIENT_URL`, `APP_URL`, and local/production defaults.
+- Auth token helpers in `lib/auth.ts` support Bearer tokens and the `session` cookie; cookie setting and clearing require `GraphQLContext.res`.
+
+## Tests
+
+- Resolver and utility tests live next to the server code as `*.test.ts`.
+- Vitest uses the Node environment from `vitest.config.ts`.


### PR DESCRIPTION
## Summary

Adds scoped `AGENTS.md` guidance for future Codex agents working in this monorepo:

- root repo-wide workspace, dependency, verification, env, and local Docker/domain guidance
- client-only Vite/React/Apollo/testing/env/deployment guidance
- server-only Apollo/Express/MongoDB/schema/build/auth/testing guidance

The files are intentionally separated so client/server-specific instructions are not duplicated in the root file.

## Validation

- `git diff --check -- AGENTS.md apps/client/AGENTS.md apps/server/AGENTS.md`
- Commit hook attempted `pnpm typecheck`, but the existing client typecheck currently fails because multiple TSX files import `semantic-ui-react` and the package/types are not installed. This PR does not change client source or dependencies.